### PR TITLE
feat: raise_synchronous option, and expose app classes

### DIFF
--- a/docs/application.md
+++ b/docs/application.md
@@ -1,3 +1,5 @@
 # Application
 
 ::: app_model.Application
+    options:
+        show_signature: false

--- a/tests/test_registries.py
+++ b/tests/test_registries.py
@@ -4,7 +4,7 @@ from app_model.registries import CommandsRegistry, KeyBindingsRegistry, MenusReg
 from app_model.types import MenuItem
 
 
-def test_menus_registry():
+def test_menus_registry() -> None:
     reg = MenusRegistry()
     reg.append_menu_items([("file", {"command": {"id": "file.new", "title": "File"}})])
     reg.append_menu_items([("file.sub", {"submenu": "Sub", "title": "SubTitle"})])
@@ -15,12 +15,12 @@ def test_menus_registry():
     assert "Sub" in str(reg)  # ok to change
 
 
-def test_keybindings_registry():
+def test_keybindings_registry() -> None:
     reg = KeyBindingsRegistry()
     assert "(0 bindings)" in repr(reg)
 
 
-def test_commands_registry():
+def test_commands_registry() -> None:
     reg = CommandsRegistry()
     reg.register_command("my.id", lambda: None, "My Title")
     assert "(1 commands)" in repr(reg)
@@ -28,3 +28,15 @@ def test_commands_registry():
 
     with pytest.raises(ValueError, match="Command 'my.id' already registered"):
         reg.register_command("my.id", lambda: None, "My Title")
+
+
+def test_commands_raises() -> None:
+    reg = CommandsRegistry(raise_synchronous_exceptions=True)
+
+    def raise_exc() -> None:
+        raise RuntimeError("boom")
+
+    reg.register_command("my.id", raise_exc, "My Title")
+
+    with pytest.raises(RuntimeError, match="boom"):
+        reg.execute_command("my.id")


### PR DESCRIPTION
makes it easier for applications to override their registry classes, and also adds a `raise_synchronous_exceptions` option (defaults to False) that, when True, will raise any exceptions encountered during `execute_command` in a synchronous context