### PR TITLE
feat: eval expr when creating menus

### DIFF
--- a/src/app_model/backends/qt/_qaction.py
+++ b/src/app_model/backends/qt/_qaction.py
@@ -157,6 +157,14 @@ class QMenuItemAction(QCommandRuleAction):
             self._app.destroyed.connect(lambda: QMenuItemAction._cache.pop(key, None))
             self._initialized = True
 
+        # by updating from an empty context, anything that declares a "constant"
+        # enablement expression (like `'False'`) will be evaluated, allowing any
+        # menus that are always on/off, to be shown/hidden as needed.
+        # Everything else will fail without a proper context.
+        # TODO: as we improve where the context comes from, this could be removed.
+        with contextlib.suppress(NameError):
+            self.update_from_context({})
+
     def update_from_context(self, ctx: Mapping[str, object]) -> None:
         """Update the enabled/visible state of this menu item from `ctx`."""
         super().update_from_context(ctx)

--- a/src/app_model/types/_command_rule.py
+++ b/src/app_model/types/_command_rule.py
@@ -66,7 +66,7 @@ class CommandRule(_BaseModel):
         "the UI. Menus pick either `title` or `short_title` depending on the context "
         "in which they show commands.",
     )
-    toggled: Union[expressions.Expr, ToggleRule, None] = Field(
+    toggled: Union[ToggleRule, expressions.Expr, None] = Field(
         None,
         description="(Optional) Condition under which the command should appear "
         "checked/toggled in any GUI representation (like a menu or button).",


### PR DESCRIPTION
this makes it possible to declare an action or menu item with `enablement: False` (perhaps based on an environment variable or setting or something) to immediately hide it