### PR TITLE
feat: use custom root type for KeyBinding

### DIFF
--- a/src/app_model/types/_keys/_keybindings.py
+++ b/src/app_model/types/_keys/_keybindings.py
@@ -1,7 +1,9 @@
 import re
-from typing import Any, Callable, Dict, Generator, List, Optional, Tuple
+from typing import Any, Callable, Dict, Generator, List, Optional, Tuple, no_type_check
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, PrivateAttr
+from pydantic.error_wrappers import ErrorWrapper, ValidationError
+from pydantic.errors import ListError, ListMinLengthError
 
 from .._constants import OperatingSystem
 from ._key_codes import KeyChord, KeyCode, KeyMod
@@ -136,10 +138,70 @@ class KeyBinding(BaseModel):
     the two keypress codes with a space. For example, 'Ctrl+K Ctrl+C'.
     """
 
-    parts: List[SimpleKeyBinding] = Field(..., min_items=1)
+    __root__: str
+    _parts: List[SimpleKeyBinding] = PrivateAttr()
+
+    def __init__(self, **data: Any) -> None:
+        if "parts" in data:
+            parts = data.pop("parts")
+            if not isinstance(parts, List):
+                raise ValidationError(
+                    errors=[ErrorWrapper(exc=ListError(), loc=("parts",))],
+                    model=self.__class__,
+                )
+            parts = [SimpleKeyBinding.validate(part) for part in parts]
+        elif "__root__" in data:
+            root = data["__root__"]
+            parts = [SimpleKeyBinding.from_str(part) for part in root.split()]
+        else:
+            parts = []
+
+        if len(parts) < 1:
+            raise ValidationError(
+                errors=[
+                    ErrorWrapper(ListMinLengthError(limit_value=1), loc=("parts",))
+                ],
+                model=self.__class__,
+            )
+        data["__root__"] = " ".join(str(part) for part in parts)
+
+        super().__init__(**data)
+        self._parts = parts
+
+    @property
+    def parts(self) -> List[SimpleKeyBinding]:
+        """Key combinations that make up the overall key chord."""
+        return self._parts
+
+    @no_type_check
+    def __setattr__(self, key, val):
+        if key == "__root__":
+            parts = [SimpleKeyBinding.from_str(part) for part in val.split()]
+        elif key == "parts":
+            parts = val
+            if not isinstance(parts, List):
+                raise ValidationError(
+                    errors=[ErrorWrapper(exc=ListError(), loc=("parts",))],
+                    model=self.__class__,
+                )
+            parts = [SimpleKeyBinding.validate(part) for part in parts]
+        else:
+            return super().__setattr__(key, val)
+
+        # key will always be either '__root__' or 'parts'
+        if len(parts) < 1:
+            raise ValidationError(
+                errors=[
+                    ErrorWrapper(ListMinLengthError(limit_value=1), loc=("parts",))
+                ],
+                model=self.__class__,
+            )
+
+        self._parts = parts
+        return super().__setattr__("__root__", " ".join(str(part) for part in parts))
 
     def __str__(self) -> str:
-        return " ".join(str(part) for part in self.parts)
+        return self.__root__
 
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, KeyBinding):
@@ -163,8 +225,7 @@ class KeyBinding(BaseModel):
     @classmethod
     def from_str(cls, key_str: str) -> "KeyBinding":
         """Parse a string into a SimpleKeyBinding."""
-        parts = [SimpleKeyBinding.from_str(part) for part in key_str.split()]
-        return cls(parts=parts)
+        return cls(__root__=key_str)
 
     @classmethod
     def from_int(

--- a/tests/test_keybindings.py
+++ b/tests/test_keybindings.py
@@ -108,7 +108,7 @@ def test_in_model():
             json_encoders = {KeyBinding: str}
 
     m = M(key="Shift+A B")
-    assert m.json(models_as_dict=False) == '{"key": "Shift+A B"}'
+    assert m.json() == '{"key": "Shift+A B"}'
 
 
 def test_standard_keybindings():

--- a/tests/test_keybindings.py
+++ b/tests/test_keybindings.py
@@ -75,6 +75,22 @@ def test_chord_keybinding():
     assert KeyBinding.validate(kb) == kb
 
 
+def test_custom_root_type():
+    kb = KeyBinding.from_str("shift+a cmd+9")
+
+    assert str(kb) == "Shift+A Meta+9"
+    assert kb.parts == [
+        SimpleKeyBinding.from_str("Shift+A"),
+        SimpleKeyBinding.from_str("Cmd+9"),
+    ]
+
+    kb.__root__ = "Ctrl+C Ctrl+V"
+    assert kb.parts == [
+        SimpleKeyBinding.from_str("Ctrl+C"),
+        SimpleKeyBinding.from_str("Ctrl+V"),
+    ]
+
+
 def test_in_dict():
     a = SimpleKeyBinding.from_str("Shift+A")
     b = KeyBinding.from_str("Shift+B")


### PR DESCRIPTION
Use a custom root type so that `models_as_dict=False` does not need to be passed to the `.json()` method since [this parameter does not get passed recursively along models](https://napari.zulipchat.com/#narrow/stream/212875-general/topic/pydantic.20model.20serialization/near/300440462). This changes the `.dict()` method to replace `KeyBinding` with its `__root__`, which is a `str`, thus effectively having the data represented as a string for serialization purposes while still being able to access the rest of the functionality attached to the `KeyBinding` class.

If I have implemented this correctly, there should be no effective changes to the API.