### PR TITLE
feat: convert keybinding to normal class

### DIFF
--- a/src/app_model/backends/qt/_qkeymap.py
+++ b/src/app_model/backends/qt/_qkeymap.py
@@ -257,7 +257,9 @@ def qkeycombo2modelkey(key: QKeyCombination) -> Union[KeyCode, KeyCombo]:
 def qkeysequence2modelkeybinding(key: QKeySequence) -> KeyBinding:
     """Return KeyBinding from QKeySequence."""
     # FIXME: this should return KeyChord instead of KeyBinding... but that only takes 2
-    return KeyBinding(parts=[qkeycombo2modelkey(x) for x in key])
+    return KeyBinding(
+        parts=[SimpleKeyBinding.from_int(qkeycombo2modelkey(x)) for x in key]
+    )
 
 
 # ################# These are the Qkeys we currently aren't mapping ################ #

--- a/src/app_model/types/_keys/_keybindings.py
+++ b/src/app_model/types/_keys/_keybindings.py
@@ -111,7 +111,7 @@ class SimpleKeyBinding(BaseModel):
 
     @classmethod
     def __get_validators__(cls) -> Generator[Callable[..., Any], None, None]:
-        yield cls.validate
+        yield cls.validate  # pragma: no cover
 
     @classmethod
     def validate(cls, v: Any) -> "SimpleKeyBinding":
@@ -208,7 +208,7 @@ class KeyBinding:
 
     @classmethod
     def __get_validators__(cls) -> Generator[Callable[..., Any], None, None]:
-        yield cls.validate
+        yield cls.validate  # pragma: no cover
 
     @classmethod
     def validate(cls, v: Any) -> "KeyBinding":

--- a/tests/test_keybindings.py
+++ b/tests/test_keybindings.py
@@ -106,7 +106,7 @@ def test_in_model():
             json_encoders = {KeyBinding: str}
 
     m = M(key="Shift+A B")
-    assert m.json(models_as_dict=False) == '{"key": "Shift+A B"}'
+    assert m.json() == '{"key": "Shift+A B"}'
 
 
 def test_standard_keybindings():

--- a/tests/test_keybindings.py
+++ b/tests/test_keybindings.py
@@ -85,19 +85,17 @@ def test_in_dict():
         }
     except TypeError as e:
         if str(e).startswith("unhashable type"):
-            pytest.fail("keybinds not hashable")
+            pytest.fail(f"keybinds not hashable: {e}")
         else:
             raise e
 
-    assert kbs[hash(a)] == 0
-    assert kbs[hash(b)] == 1
+    assert kbs[a] == 0
+    assert kbs[b] == 1
 
-    new_a = KeyBinding.from_int(hash(a))
+    new_a = KeyBinding.from_str("Shift+A")
 
     with pytest.raises(KeyError):
         kbs[new_a]
-
-    assert kbs[hash(new_a)] == 0
 
 
 def test_in_model():


### PR DESCRIPTION
this is an idea PR to convert keybinding to a normal class instead of a base model to allow it to be represented properly in json and yaml without complicated workarounds