### PR TITLE
refactor: Use a dict (as an ordered set) instead of a list for menus registry

### DIFF
--- a/src/app_model/registries/_menus_reg.py
+++ b/src/app_model/registries/_menus_reg.py
@@ -29,7 +29,7 @@ class MenusRegistry:
     menus_changed = Signal(set)
 
     def __init__(self) -> None:
-        self._menu_items: Dict[MenuId, List[MenuOrSubmenu]] = {}
+        self._menu_items: Dict[MenuId, Dict[MenuOrSubmenu, None]] = {}
 
     def append_menu_items(
         self, items: Sequence[Tuple[MenuId, MenuOrSubmenu]]
@@ -50,12 +50,12 @@ class MenusRegistry:
         disposers: List[Callable[[], None]] = []
         for menu_id, item in items:
             item = MenuItem.validate(item)  # type: ignore
-            menu_list = self._menu_items.setdefault(menu_id, [])
-            menu_list.append(item)
+            menu_dict = self._menu_items.setdefault(menu_id, {})
+            menu_dict[item] = None
             changed_ids.add(menu_id)
 
-            def _remove(lst: list = menu_list, _item: Any = item) -> None:
-                lst.remove(_item)
+            def _remove(dct: dict = menu_dict, _item: Any = item) -> None:
+                dct.pop(_item, None)
 
             disposers.append(_remove)
 
@@ -83,7 +83,7 @@ class MenusRegistry:
     def get_menu(self, menu_id: MenuId) -> List[MenuOrSubmenu]:
         """Return menu items for `menu_id`."""
         # using method rather than __getitem__ so that subclasses can use arguments
-        return self._menu_items[menu_id]
+        return list(self._menu_items[menu_id])
 
     def __repr__(self) -> str:
         name = self.__class__.__name__


### PR DESCRIPTION
This changes the `MenusRegistry` class to use a dict in place of a list for the internal storage of menu items. The benefit here is when disposing it does not have to repeatedly call `list.remove`, which performs a linear search each time. Instead the dict acts as an ordered set and removing items takes constant time.

This is probably not an important optimization in general usage, but I believe it fixes a significant regression in napari test times. I think it's due to this `autouse` fixture introduced a few weeks ago: https://github.com/napari/napari/blob/1cc90a74211c6cbf3fc644da5866f9752cf1ac78/napari/conftest.py#L448
There may be other ways to fix/workaround it (maybe the fixture just needs better scoping?) so this PR is just meant to start a discussion.

Here's a chunk of some profiling output that pointed me to this bottleneck:
![Screen Shot 2022-11-04 at 8 31 11 PM](https://user-images.githubusercontent.com/1231828/200093391-4274c46d-0356-4cce-8f9a-36f5c5c6dee3.png)

Here's a link to a successful CI run using this change in my napari fork. CI times are somewhere around 25-30% (~4 min) faster for most platforms (macOS is still ridiculously slow for some reason):
https://github.com/aganders3/napari/actions/runs/3397096945

I saw similar results running tests locally with test time decreasing significantly:
```
% /usr/bin/time pytest --maxfail=0  # test with released app-model
...
      217.81 real       544.61 user        75.52 sys

% pip install -e ~/src/app-model  # install app-model from this branch
% /usr/bin/time pytest --maxfail=0  # test with app-model from this branch
...
      134.89 real       370.35 user        70.27 sys
```