### PR TITLE
fix: fix unsupported operand

### DIFF
--- a/src/app_model/backends/qt/_qkeymap.py
+++ b/src/app_model/backends/qt/_qkeymap.py
@@ -9,11 +9,9 @@ from ...types._constants import OperatingSystem
 from ...types._keys import KeyBinding, KeyCode, KeyCombo, KeyMod, SimpleKeyBinding
 
 try:
-    from qtpy import PYQT6, QT6
+    from qtpy import QT6
 except ImportError:
     QT6 = False
-    PYQT6 = False
-
 
 QMETA = Qt.KeyboardModifier.MetaModifier
 QCTRL = Qt.KeyboardModifier.ControlModifier

--- a/src/app_model/backends/qt/_qkeymap.py
+++ b/src/app_model/backends/qt/_qkeymap.py
@@ -66,7 +66,7 @@ else:
         return int(out)
 
 
-if PYQT6:
+if QT6:
 
     def _get_qmods(key: QKeyCombination) -> Qt.KeyboardModifier:
         return key.keyboardModifiers()


### PR DESCRIPTION
fixes `unsupported operand type(s) for &: 'PySide6.QtCore.QKeyCombination' and 'KeyboardModifier'` on the newest pyside6

side-note: fixes in https://github.com/napari/superqt/pull/133 should get pyside6 tests working again